### PR TITLE
Send badge awarded events through the event system.

### DIFF
--- a/qa-badge-check.php
+++ b/qa-badge-check.php
@@ -616,17 +616,15 @@
 				'VALUES (NOW(), 1, #, #, $, 0)',
 				$object_id, $user_id, $badge_slug
 			);
-			
-			if(qa_opt('event_logger_to_database')) { // add event
-				
-				$handle = qa_getHandleFromId($user_id);
-				
-				qa_db_query_sub(
-					'INSERT INTO ^eventlog (datetime, ipaddress, userid, handle, cookieid, event, params) '.
-					'VALUES (NOW(), $, $, $, #, $, $)',
-					qa_remote_ip_address(), $user_id, $handle, qa_cookie_get(), 'badge_awarded', 'badge_slug='.$badge_slug.($object_id?"\t".'postid='.$object_id:'')
-				);
+
+			// raise an event
+
+			$event_params = array('badge_slug' => $badge_slug);
+			if ($object_id) {
+				$event_params['postid'] = $object_id;
 			}
+			
+			qa_report_event('badge_awarded', $user_id, qa_getHandleFromId($user_id), qa_cookie_get(), $event_params);
 			
 			if(qa_opt('badge_email_notify')) qa_badge_notification($user_id, $object_id, $badge_slug);	
 			

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -217,17 +217,15 @@
 						//qa_db_usernotice_create($uid, $content, 'html');
 						
 						if(qa_opt('badge_email_notify') && $notify == 1) qa_badge_notification($uid, $oid, $badge_slug);
-						
-						if(qa_opt('event_logger_to_database')) { // add event
-							
-							$handle = qa_getHandleFromId($uid);
-							
-							qa_db_query_sub(
-								'INSERT INTO ^eventlog (datetime, ipaddress, userid, handle, cookieid, event, params) '.
-								'VALUES (NOW(), $, $, $, #, $, $)',
-								qa_remote_ip_address(), $uid, $handle, qa_cookie_get(), 'badge_awarded', 'badge_slug='.$badge_slug.($oid?"\t".'postid='.$oid:'')
-							);
+
+						// raise an event
+
+						$event_params = array('badge_slug' => $badge_slug);
+						if ($iod) {
+							$event_params['postid'] = $iod;
 						}
+						
+						qa_report_event('badge_awarded', $uid, qa_getHandleFromId($uid), qa_cookie_get(), $event_params);
 					}
 					
 					array_push($awarded,$badge_slug);


### PR DESCRIPTION
Instead of writing badge awarded events directly to the database, they're now sent through the event system. The result of this is the same, except that with this change, other plugins can also receive badge awareded events.